### PR TITLE
e5han: fix(build): preserve design-system CDN <link> in production HTML

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -71,12 +71,14 @@ async function createProductionHTML() {
     const buildCommit = getBuildCommit();
     const buildVersion = getBuildVersion();
     
-    // Replace vendor CSS and individual CSS files with bundled version
+    // Replace vendor CSS and individual CSS files with bundled version.
+    // Keeps the Gruene-AT design-system CDN <link> intact so the brand
+    // tokens (var(--gat-*)) used by the bundled Tailwind utilities resolve.
     html = html.replace(
         /<link rel="stylesheet" href="vendors\/fontawesome\/css\/all\.css"\s*\/?>[\s\S]*?<link rel="stylesheet"[\s\S]*?href="resources\/css\/style\.css\?v=[\d\.]+"\s*\/?>/g,
-        '<link rel="stylesheet" href="app.min.css">'
+        '<link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css">\n    <link rel="stylesheet" href="app.min.css">'
     );
-    
+
     // Replace vendor JavaScript files with bundled version
     const vendorReplacePattern = /<script src="vendors\/jquery\/jquery-3\.7\.1\.min\.js"><\/script>[\s\S]*?<script src="vendors\/qrcode\.min\.js"><\/script>/g;
     html = html.replace(vendorReplacePattern, 
@@ -111,7 +113,7 @@ async function createStaticPage(filename) {
 
     html = html.replace(
         /<link rel="stylesheet" href="vendors\/fontawesome\/css\/all\.css"\s*\/?>[\s\S]*?<link rel="stylesheet"[\s\S]*?href="resources\/css\/style\.css\?v=[\d\.]+"\s*\/?>/g,
-        '<link rel="stylesheet" href="app.min.css">'
+        '<link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css">\n    <link rel="stylesheet" href="app.min.css">'
     );
 
     const timestamp = Date.now();


### PR DESCRIPTION
## Summary

Follow-up to #27 (Phase 0 von #26). The production HTML builder collapses every per-source stylesheet `<link>` into a single bundled `app.min.css` reference, and its regex swallowed the design-system CDN `<link>` we added in #27. The dev `index.html` was correct, but the deployed `build/index.html` shipped without the design-system stylesheet, so the brand tokens (`var(--gat-color-*)`) referenced by the Tailwind utilities had no source.

Fix: emit the design-system `<link>` alongside `app.min.css` in `createProductionHTML()` and `createStaticPage()`.

## Verification (after merge & deploy)

```
curl -sL https://bildgenerator.gruene.at/ | grep design-system.css
```

should print the new `<link>` line.

## Test plan

- [ ] CI gruen
- [ ] Live site `curl` returns the design-system CSS link
- [ ] Brand colors look unchanged (DS provides matching `--gat-color-primary` etc.)