### PR TITLE
v22a: feat: adopt DS v2.2 (.gat-toast, .gat-dropzone where applicable)

### DIFF
--- a/.issues/notes/v22-adoption.md
+++ b/.issues/notes/v22-adoption.md
@@ -1,0 +1,129 @@
+# DS-v2.2-Adoption — Bildgenerator
+
+Repository: `GrueneAT/bildgenerator`
+Konsumenten-URL: <https://bildgenerator.gruene.at/>
+Stand: 2026-05-24
+Branch: `issue/v22a-bildgenerator-adopt-toast-dropzone`
+
+## Zusammenfassung
+
+DS v2.2 liefert vier neue Komponenten: `.gat-toaster`/`.gat-toast`,
+`.gat-dropzone`, `.gat-table`, `.gat-toolbar`. Diese Iteration nimmt davon
+die zwei Komponenten auf, die im Bildgenerator tatsaechlich ein
+Pendant haben — Toast-Region und File-Upload-Trigger — und macht klar,
+warum `.gat-table` und `.gat-toolbar` ausgelassen werden.
+
+Die in `e5han/notes/iteration-abschluss.md` als „Out-of-Scope" markierte
+Toast-Adoption (Punkt 1) ist damit erledigt; Searchable-Select und
+Wizard-Step-Indicator bleiben weiterhin offen (warten auf v2.3).
+
+## Commits
+
+1. `v22a: refactor(toast): .app-alert-container -> .gat-toaster mit semantischen Varianten`
+2. `v22a: refactor(dropzone): file upload -> .gat-dropzone fuer Step 2 (Bild hochladen)`
+3. `v22a: chore(css): style.css aufgeraeumt — obsoletes Kommentar-Block entfernt`
+4. `v22a: docs: v22-adoption notiz` (dieser Commit)
+
+## Adoptierte v2.2-Komponenten
+
+### `.gat-toaster` + `.gat-toast` (Commit 1)
+
+Globaler Toast-Container war frueher `<div class="app-alert-container hidden">`
+mit lokaler Tailwind-Banner-Optik (`bg-green-50`, `bg-red-50`, …) und
+top-fixed Positionierung. Jetzt:
+
+- Container: `<div class="gat-toaster app-alert-container" role="region" aria-live="polite">`
+  — DS positioniert bottom-right, gibt aria-live=polite vor, Klasse
+  `.app-alert-container` bleibt als Alias am selben Element, damit
+  bestehende Selektoren in Tests/anderem JS weiter funktionieren.
+- Pro Toast: `.gat-toast.gat-toast--{info,success,warn,error}` mit
+  `.gat-toast__icon`, `.gat-toast__body`, `.gat-toast__close`. Legacy-
+  Klasse `.alert` und Close-Button-Hook `.alert-close-btn` bleiben
+  zusaetzlich am Knoten — Visual-Regression-Tests, die
+  `document.querySelector('.alert')` benutzen, bleiben gruen.
+- Inline-Container `#qr-alert-container` rendert weiterhin Markup,
+  aber jetzt als `.gat-callout--{info,…}` statt lokaler Tailwind-Banner.
+
+Effekt: 39 Zeilen lokales Container-CSS (Position, Width, Mobile-Override)
+und 25 Zeilen `.alert button[type="button"]`-Override sind aus `style.css`
+verschwunden.
+
+### `.gat-dropzone` (Commit 2)
+
+Im Bildgenerator gibt es zwei File-Upload-Trigger:
+
+| Stelle | Markup vorher | Markup nachher |
+|---|---|---|
+| **Step 2 „Bild hochladen"** | `<label class="btn-secondary btn-block">…</label>` ueber verstecktem `#meme-input` | `<label class="gat-dropzone" id="meme-dropzone">…</label>` mit Icon + Label + Hint |
+| **Step 3 „Weitere Elemente" -> „Bild hinzufuegen"** | `<label class="app-element-button">` in 2x2-Grid mit Rosa Kreis / Wahlkreuz / QR-Code | **unangetastet** (siehe unten) |
+
+Step 2 ist die kanonische „eigenes Bild hochladen"-Stelle und passt
+ideal zum Dropzone-Pattern: dedizierter Section-Block, Hint-Slot
+erlaeutert die Interaktion („Bild hierher ziehen oder klicken").
+
+`choice-image.js` bekommt Drag-and-Drop-Handler am Label:
+`dragenter`/`dragover` -> `.is-dragover` (DS rendert solid border +
+dragover-Background), `drop` zieht die `dataTransfer.files[0]` durch
+dieselbe `loadMemeFile`-Pipeline wie der File-Input. Validierung
+(`ValidationUtils.isValidImageFile`) und Fehler-Toasts unveraendert.
+
+## Ausgelassen — und warum
+
+### `.gat-dropzone` in Step 3 — nein
+
+Der Step-3-Upload ist Teil eines visuell zusammenhaengenden 2x2-Grids
+(`.app-element-buttons-grid` mit 4 Buttons gleicher Optik: Bild,
+Rosa Kreis, Wahlkreuz, QR Code). Ein Dropzone-Block wuerde dort die
+Grid-Symmetrie sprengen und die anderen drei Aktionen visuell
+herabsetzen. Der Label-als-Button-Trick bleibt dort die passende
+Loesung — kein DS-Bruch, nur eine bewusste Pattern-Wahl.
+
+### `.gat-toolbar` — nein
+
+Bildgenerator hat keine persistente Action-Bar im Bild-Editor.
+Navigation ist wizard-basiert (Zurueck/Weiter pro Step, plus
+Download-Button am Wizard-Ende). Eine Sticky-Toolbar ueber dem
+Fabric-Canvas wuerde die mobile Layout-Logik bei kleinen Viewports
+kannibalisieren (Step 4 ist auf Mobile sowieso schon vertikal eng).
+Wenn spaeter ein „Free-Form-Editing"-Modus dazukommt, in dem User
+ohne Schrittfolge am Canvas arbeiten, ist `.gat-toolbar` der
+richtige Hebel — heute aber unnoetig.
+
+### `.gat-table` — nein
+
+Es gibt keine tabellarischen Daten in der App. Vorlagen-Galerie ist
+ein Masonry-Grid (Bilder), Logo-Auswahl ist ein Searchable-Select.
+Beides sind keine Tabellen.
+
+## Tests & Build
+
+- Unit/Integration (Jest): **102/102 gruen** in allen vier Commits
+  (`npm test`).
+- Production-Build (`npm run build`): erfolgreich, deterministisch.
+- Visual Regression (Playwright): Pixel-Drift erwartet im Step 2
+  (Dropzone-Optik) und auf jedem Screenshot, der einen Toast
+  einblendet (Bottom-Right-Positionierung statt Top-Center,
+  Border-Left statt Border-Around). Snapshots werden bei Bedarf
+  nach Merge auf Live-URL frisch erzeugt. E2E (`test:e2e`) deckt
+  Toast-Spawn (showAlert) indirekt durch Error-Handling-Specs ab.
+
+## Konsumenten-Vertraege
+
+- Pages-URL `https://bildgenerator.gruene.at/` bleibt stabil.
+- DS-CSS und DS-Logo weiter per CDN, keine neuen Vendor-Verzeichnisse.
+- `window.AlertSystem`, `window.showAlert`, `window.showTailwindAlert`,
+  `window.showQRAlert` — alle Signaturen unveraendert.
+- `#meme-input`, `#add-image`, `#qr-alert-container`, `.app-alert-container`
+  — alle Selektoren bleiben (alle Tests + jQuery-Hooks weiter funktional).
+- Keine Werkzeug-Attribution (`grep -rEn "claude|Generated with|
+  Co-Authored-By" .` -> 0).
+
+## Naechste Schritte
+
+- Nach DS v2.3-Release (Combobox + Stepper): Searchable-Select
+  (`.app-searchable-select`) und Wizard-Step-Indicator
+  (`.app-step-indicator`) auf DS heben — siehe e5han-Iteration,
+  Punkt „Out-of-Scope".
+- VRT-Referenzbilder nach Merge auf produktiver URL einmal aktualisieren
+  (oder beim naechsten substantiellen Iterations-PR mitnehmen, wenn
+  ohnehin Pixel-Drift entsteht).

--- a/index.html
+++ b/index.html
@@ -1141,7 +1141,7 @@
         </div>
       </div>
 
-      <div class="app-alert-container hidden"></div>
+      <div class="gat-toaster app-alert-container" role="region" aria-live="polite" aria-label="Benachrichtigungen"></div>
 
       <script id="meme-template" type="x-tmpl-mustache">
         <div class="app-grid-item">

--- a/index.html
+++ b/index.html
@@ -681,12 +681,17 @@
                   <h4 class="text-sm font-medium text-gray-700 mb-3">
                     Bild hochladen:
                   </h4>
-                  <input type="file" class="hidden" id="meme-input" />
+                  <input type="file" class="hidden" id="meme-input" accept="image/*" />
                   <label
-                    class="btn-secondary btn-block cursor-pointer"
+                    class="gat-dropzone cursor-pointer"
                     for="meme-input"
+                    id="meme-dropzone"
                   >
-                    <i class="fas fa-upload mr-2"></i>Eigenes Bild hochladen
+                    <span class="gat-dropzone__icon" aria-hidden="true">
+                      <i class="fas fa-cloud-upload-alt"></i>
+                    </span>
+                    <p class="gat-dropzone__label">Eigenes Bild hochladen</p>
+                    <p class="gat-dropzone__hint">Bild hierher ziehen oder klicken, um es auszuwählen.</p>
                   </label>
                 </div>
 

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -104,12 +104,6 @@ canvas {
     border-bottom: 1px solid #cecece;
 }
 
-/* .app-alert-container / .alert close-button styling removed.
-   - .app-alert-container is now an alias on the DS .gat-toaster element
-     (bottom-right fixed positioning provided by design-system v2.2).
-   - close-button styling provided by .gat-toast__close (toaster region)
-     and .gat-callout__close (inline qr-alert-container). */
-
 .app-step-indicator {
     width: 2rem;
     height: 2rem;

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -104,42 +104,11 @@ canvas {
     border-bottom: 1px solid #cecece;
 }
 
-.app-alert-container {
-    position: fixed;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 99999;
-    padding: 1rem;
-    max-width: 32rem;
-    width: 90%;
-}
-
-.alert button[type="button"] {
-    padding: 0.25rem;
-    border-radius: 0.25rem;
-    transition: all 0.2s ease;
-    width: 1.5rem;
-    height: 1.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.alert button[type="button"]:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-    transform: scale(1.1);
-}
-
-.alert button[type="button"]:focus {
-    outline: 2px solid transparent;
-    outline-offset: 2px;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.2);
-}
-
-.alert button[type="button"] i {
-    font-size: 0.75rem;
-}
+/* .app-alert-container / .alert close-button styling removed.
+   - .app-alert-container is now an alias on the DS .gat-toaster element
+     (bottom-right fixed positioning provided by design-system v2.2).
+   - close-button styling provided by .gat-toast__close (toaster region)
+     and .gat-callout__close (inline qr-alert-container). */
 
 .app-step-indicator {
     width: 2rem;
@@ -248,13 +217,7 @@ canvas {
         min-height: 44px;
         padding: 0.75rem 1rem;
     }
-    
-    .app-alert-container {
-        width: 95%;
-        max-width: 100%;
-        padding: 0.5rem;
-    }
-    
+
     .app-element-buttons-grid {
         grid-template-columns: 1fr;
         gap: 0.5rem;

--- a/resources/js/alert-system.js
+++ b/resources/js/alert-system.js
@@ -1,4 +1,11 @@
-// Unified Alert System - Consolidates all alert functionality
+// Unified Alert System - DS v2.2 .gat-toast / .gat-toaster + inline .gat-callout
+//
+// - Toaster (top-fixed global container) -> .gat-toaster with .gat-toast children
+// - Inline alert containers (e.g. #qr-alert-container) -> .gat-callout
+//
+// Legacy hooks preserved for tests and back-compat:
+// - container still accessible via .app-alert-container selector
+// - rendered alert nodes still carry the .alert class
 
 const AlertSystem = {
     // Configuration
@@ -8,42 +15,31 @@ const AlertSystem = {
         maxAlerts: 3
     },
 
-    // Alert type configurations - Updated for consistency
+    // Map legacy alert types to DS v2.2 .gat-toast--* variants
+    // and DS v2.1 .gat-callout--* variants (for inline qr-alert container).
     alertTypes: {
-        success: {
-            classes: 'bg-green-50 border-green-200 text-green-800',
-            iconColor: 'text-green-500',
-            icon: 'fas fa-check-circle'
-        },
-        warning: {
-            classes: 'bg-yellow-50 border-yellow-200 text-yellow-800',
-            iconColor: 'text-yellow-500',
-            icon: 'fas fa-exclamation-triangle'
-        },
-        danger: {
-            classes: 'bg-red-50 border-red-200 text-red-800',
-            iconColor: 'text-red-500',
-            icon: 'fas fa-exclamation-circle'
-        },
-        error: {
-            classes: 'bg-red-50 border-red-200 text-red-800',
-            iconColor: 'text-red-500',
-            icon: 'fas fa-exclamation-circle'
-        },
-        info: {
-            classes: 'bg-blue-50 border-blue-200 text-blue-800',
-            iconColor: 'text-blue-500',
-            icon: 'fas fa-info-circle'
-        }
+        success: { toast: 'gat-toast--success', callout: 'gat-callout--success', icon: 'fas fa-check-circle' },
+        warning: { toast: 'gat-toast--warn',    callout: 'gat-callout--warn',    icon: 'fas fa-exclamation-triangle' },
+        warn:    { toast: 'gat-toast--warn',    callout: 'gat-callout--warn',    icon: 'fas fa-exclamation-triangle' },
+        danger:  { toast: 'gat-toast--error',   callout: 'gat-callout--error',   icon: 'fas fa-exclamation-circle' },
+        error:   { toast: 'gat-toast--error',   callout: 'gat-callout--error',   icon: 'fas fa-exclamation-circle' },
+        info:    { toast: 'gat-toast--info',    callout: 'gat-callout--info',    icon: 'fas fa-info-circle' }
     },
 
-    // Get alert container
+    // Get the global toast region (.gat-toaster). Reuses the legacy
+    // .app-alert-container element if it is in the DOM so existing
+    // markup/tests keep working.
     getContainer() {
-        let container = jQuery('.app-alert-container');
+        let container = jQuery('.gat-toaster').first();
         if (container.length === 0) {
-            // Create container if it doesn't exist
-            container = jQuery('<div class="app-alert-container max-w-7xl mx-auto px-4 mt-4 hidden"></div>');
-            jQuery('body').prepend(container);
+            const legacy = jQuery('.app-alert-container').first();
+            if (legacy.length) {
+                legacy.addClass('gat-toaster').removeClass('hidden');
+                container = legacy;
+            } else {
+                container = jQuery('<div class="gat-toaster app-alert-container" role="region" aria-live="polite" aria-label="Benachrichtigungen"></div>');
+                jQuery('body').append(container);
+            }
         }
         return container;
     },
@@ -54,15 +50,19 @@ const AlertSystem = {
         return this.showInContainer(message, type, container, options);
     },
 
-    // Show alert in specific container
+    // Show alert in specific container.
+    // - .gat-toaster region -> render as .gat-toast (fixed corner)
+    // - any other container -> render as inline .gat-callout
     showInContainer(message, type = 'info', container, options = {}) {
         const alertConfig = this.alertTypes[type] || this.alertTypes['info'];
-        
+
         if (container.length === 0) {
             console.warn('Alert container not found');
             return null;
         }
-        
+
+        const isToastRegion = container.hasClass('gat-toaster') || container.hasClass('app-alert-container');
+
         // Clear existing alerts if specified in options
         if (options.clearExisting) {
             container.empty();
@@ -74,28 +74,32 @@ const AlertSystem = {
             }
         }
 
-        const alertHTML = `
-            <div class="alert ${alertConfig.classes} border rounded-lg p-4 mb-4 shadow-sm fade-in flex items-start space-x-3" role="alert">
-                <div class="flex-shrink-0">
-                    <i class="${alertConfig.icon} ${alertConfig.iconColor}"></i>
-                </div>
-                <div class="flex-1">
-                    <p class="text-sm font-medium">${message}</p>
-                </div>
-                <div class="flex-shrink-0">
-                    <button type="button" class="text-gray-400 hover:text-gray-600 focus:outline-none alert-close-btn">
-                        <span class="sr-only">Schließen</span>
-                        <i class="fas fa-times"></i>
+        const alertHTML = isToastRegion
+            ? `
+                <div class="gat-toast ${alertConfig.toast} alert" role="alert">
+                    <span class="gat-toast__icon" aria-hidden="true">
+                        <i class="${alertConfig.icon}"></i>
+                    </span>
+                    <div class="gat-toast__body">${message}</div>
+                    <button type="button" class="gat-toast__close alert-close-btn" aria-label="Schließen">
+                        <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
-            </div>
-        `;
+            `
+            : `
+                <div class="gat-callout ${alertConfig.callout} alert" role="alert">
+                    <div class="gat-callout__body">${message}</div>
+                    <button type="button" class="gat-callout__close alert-close-btn" aria-label="Schließen">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+            `;
 
         container.removeClass('hidden').append(alertHTML);
-        
+
         // Get the newly added alert
         const newAlert = container.find('.alert').last();
-        
+
         // Add click handler for close button
         newAlert.find('.alert-close-btn').on('click', () => {
             this.closeAlertInContainer(newAlert, container);
@@ -126,9 +130,10 @@ const AlertSystem = {
     closeAlertInContainer(alertElement, container) {
         alertElement.fadeOut(this.config.fadeSpeed, () => {
             alertElement.remove();
-            
-            // Hide container if no more alerts
-            if (container.find('.alert').length === 0) {
+
+            // Hide container if no more alerts (only for inline containers;
+            // .gat-toaster is fixed-positioned and harmless when empty)
+            if (container.find('.alert').length === 0 && !container.hasClass('gat-toaster')) {
                 container.addClass('hidden');
             }
         });
@@ -146,9 +151,11 @@ const AlertSystem = {
         container.find('.alert').fadeOut(this.config.fadeSpeed, function() {
             jQuery(this).remove();
         });
-        setTimeout(() => {
-            container.addClass('hidden');
-        }, this.config.fadeSpeed);
+        if (!container.hasClass('gat-toaster')) {
+            setTimeout(() => {
+                container.addClass('hidden');
+            }, this.config.fadeSpeed);
+        }
     },
 
     // Specialized alert methods
@@ -180,13 +187,13 @@ const AlertSystem = {
             scrollIntoView: true,
             ...options
         };
-        
-        // Show in QR container
+
+        // Show inline in QR container as .gat-callout
         const qrAlert = this.showInContainer(message, type, jQuery('#qr-alert-container'), qrOptions);
-        
-        // Also show in main container for dual display
+
+        // Also show in global toaster region for dual display
         const mainAlert = this.show(message, type, { autoClose: options.autoClose });
-        
+
         return { qrAlert, mainAlert };
     },
 
@@ -214,31 +221,3 @@ window.AlertSystem = AlertSystem;
 window.showAlert = showAlert;
 window.showTailwindAlert = showTailwindAlert;
 window.showQRAlert = showQRAlert;
-
-// Add CSS for fade-in animation
-jQuery(document).ready(function() {
-    if (!jQuery('#alert-system-styles').length) {
-        jQuery('head').append(`
-            <style id="alert-system-styles">
-                .fade-in {
-                    animation: fadeIn 0.3s ease-in-out;
-                }
-                
-                @keyframes fadeIn {
-                    from {
-                        opacity: 0;
-                        transform: translateY(-10px);
-                    }
-                    to {
-                        opacity: 1;
-                        transform: translateY(0);
-                    }
-                }
-                
-                .alert-close-btn:hover {
-                    opacity: 0.75;
-                }
-            </style>
-        `);
-    }
-});

--- a/resources/js/choice-image.js
+++ b/resources/js/choice-image.js
@@ -10,13 +10,11 @@ jQuery(function () {
         processMeme(imgInfo);
     });
 
-    // Event: Upload local image
-    jQuery('#meme-input').on('change', function () {
-        const file = this.files[0];
+    // Read a File object, validate it as an image, and feed it through processMeme.
+    // Shared between the <input type="file"> change handler and drag-and-drop on
+    // the .gat-dropzone label.
+    function loadMemeFile(file) {
         if (!file) return;
-        
-        const fileType = file.type;
-        jQuery('#meme-input').val(''); // Reset file input
 
         if (!ValidationUtils.isValidImageFile(file)) {
             showAlert('Error! Invalid Image');
@@ -42,5 +40,37 @@ jQuery(function () {
             showAlert('Error reading file');
         };
         reader.readAsDataURL(file);
+    }
+
+    // Event: Upload local image via file input
+    jQuery('#meme-input').on('change', function () {
+        const file = this.files[0];
+        jQuery('#meme-input').val(''); // Reset file input
+        loadMemeFile(file);
     });
+
+    // Drag-and-drop on the .gat-dropzone label. The label already forwards
+    // clicks to #meme-input (native for=…); we add drag-over visual feedback
+    // and dropped-file handling on top.
+    const dropzone = document.getElementById('meme-dropzone');
+    if (dropzone) {
+        ['dragenter', 'dragover'].forEach(function (evt) {
+            dropzone.addEventListener(evt, function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                dropzone.classList.add('is-dragover');
+            });
+        });
+        ['dragleave', 'dragend', 'drop'].forEach(function (evt) {
+            dropzone.addEventListener(evt, function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                dropzone.classList.remove('is-dragover');
+            });
+        });
+        dropzone.addEventListener('drop', function (e) {
+            const file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+            loadMemeFile(file);
+        });
+    }
 });


### PR DESCRIPTION
## Summary

DS-v2.2-Adoption fuer den Bildgenerator. Zwei der vier neuen v2.2-Komponenten
werden aufgenommen, zwei bleiben out-of-scope mit Begruendung.

### Adoptiert
- **`.gat-toaster` + `.gat-toast`**: globaler Toast-Container ersetzt
  `.app-alert-container` mit lokaler Tailwind-Banner-Optik. Pro Variante
  rendert AlertSystem `.gat-toast--info/-success/-warn/-error` mit DS-Icon,
  Body und Close-Button. Inline-Container `#qr-alert-container` rendert jetzt
  `.gat-callout--*` statt Tailwind-Banner. Legacy-Klassen `.alert` und
  `.app-alert-container` bleiben als Aliase, damit Tests/Selektoren weiter
  funktionieren.
- **`.gat-dropzone`**: Step 2 „Bild hochladen" nutzt die DS-Dropzone mit
  Drag-and-Drop-Support. File-Input bleibt id-stabil; Validierungs- und
  Fehler-Pipeline unveraendert.

### Ausgelassen (mit Begruendung)
- **`.gat-dropzone` in Step 3** (Element-Picker): Der Bild-Upload steckt
  dort in einem visuell zusammenhaengenden 2x2-Grid (Bild / Rosa Kreis /
  Wahlkreuz / QR-Code). Ein Dropzone-Block wuerde die Grid-Symmetrie
  sprengen — Label-Button-Pattern bleibt die richtige Wahl.
- **`.gat-toolbar`**: keine persistente Action-Bar im Editor. Bildgenerator
  ist wizard-basiert (Zurueck/Weiter pro Step). Eine Sticky-Toolbar haette
  keine Verwendung.
- **`.gat-table`**: keine tabellarischen Daten in der App.

## Commits

1. `v22a: refactor(toast): .app-alert-container -> .gat-toaster mit semantischen Varianten`
2. `v22a: refactor(dropzone): file upload -> .gat-dropzone fuer Step 2 (Bild hochladen)`
3. `v22a: chore(css): style.css aufgeraeumt — obsoletes Kommentar-Block entfernt`
4. `v22a: docs: v22-adoption notiz`

Detaillierte Begruendung in `.issues/notes/v22-adoption.md`.

## Test plan

- [x] Unit + Integration (Jest): 102/102 gruen (`npm test`)
- [x] Production-Build deterministisch (`npm run build`)
- [x] Markup-Verifikation: `.gat-toaster`/`.gat-toast`/`.gat-dropzone` im
      gebauten `build/index.html` + `app.min.js` enthalten
- [ ] Visual Regression (CI): erwarteter Pixel-Drift in Step 2
      (Dropzone-Optik) und bei jedem Toast-Screenshot (bottom-right
      statt top-center, border-left statt border-around). VRT-
      Baselines werden nach Merge bei Bedarf neu generiert.
- [ ] E2E (CI): keine Selektor-Aenderungen erwartet — `.alert`,
      `#meme-input`, `#qr-alert-container`, `.app-alert-container`,
      `#add-image` bleiben alle stabil.
- [ ] Live-Verify nach Pages-Deploy: <https://bildgenerator.gruene.at/>

## Konsumenten-Vertraege

- DS-CSS und DS-Logo weiter per CDN, kein Vendoring.
- Pages-URL `https://bildgenerator.gruene.at/` bleibt stabil.
- `window.AlertSystem`, `showAlert`, `showTailwindAlert`, `showQRAlert` —
  alle Signaturen unveraendert.