### PR TITLE
feat(nav): werkzeuge-link in header (legacy)

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -31,11 +31,30 @@
             <img src="https://grueneat.github.io/design-system/assets/gruene-logo.svg" width="32" alt="Die Gruenen" />
             <h1 class="text-gray-900 text-xl font-bold">Grüner Bildgenerator</h1>
           </a>
-          <a href="mailto:florian.motlik@gruene.at"
-             class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-700 hover:text-gruene-primary transition-colors">
-            <i class="fas fa-envelope text-gray-500"></i>
-            <span class="font-medium">florian.motlik@gruene.at</span>
-          </a>
+          <div class="flex items-center gap-2 text-sm">
+            <a href="https://grueneat.github.io/werkzeuge/"
+               target="_blank"
+               rel="noopener"
+               class="hidden sm:inline-flex items-center gap-1.5 text-gray-700 hover:text-gruene-primary transition-colors"
+               title="Alle Werkzeuge der Grünen (externes Tool-Verzeichnis)">
+              <i class="fas fa-toolbox text-gray-500"></i>
+              <span class="font-medium">Werkzeuge</span>
+              <i class="fas fa-arrow-up-right-from-square text-xs text-gray-400" aria-hidden="true"></i>
+            </a>
+            <a href="https://grueneat.github.io/werkzeuge/"
+               target="_blank"
+               rel="noopener"
+               class="sm:hidden inline-flex items-center text-gray-700 hover:text-gruene-primary"
+               title="Werkzeuge der Grünen"
+               aria-label="Werkzeuge der Grünen (externes Tool-Verzeichnis)">
+              <i class="fas fa-toolbox"></i>
+            </a>
+            <a href="mailto:florian.motlik@gruene.at"
+               class="hidden sm:inline-flex items-center gap-1.5 text-gray-700 hover:text-gruene-primary transition-colors">
+              <i class="fas fa-envelope text-gray-500"></i>
+              <span class="font-medium">florian.motlik@gruene.at</span>
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,27 @@
           </div>
           <div class="flex items-center gap-2 text-sm">
             <a
+              href="https://grueneat.github.io/werkzeuge/"
+              target="_blank"
+              rel="noopener"
+              class="hidden sm:inline-flex items-center gap-1.5 text-gray-700 hover:text-gruene-primary transition-colors"
+              title="Alle Werkzeuge der Grünen (externes Tool-Verzeichnis)"
+            >
+              <i class="fas fa-toolbox text-gray-500"></i>
+              <span class="font-medium">Werkzeuge</span>
+              <i class="fas fa-arrow-up-right-from-square text-xs text-gray-400" aria-hidden="true"></i>
+            </a>
+            <a
+              href="https://grueneat.github.io/werkzeuge/"
+              target="_blank"
+              rel="noopener"
+              class="sm:hidden inline-flex items-center text-gray-700 hover:text-gruene-primary"
+              title="Werkzeuge der Grünen"
+              aria-label="Werkzeuge der Grünen (externes Tool-Verzeichnis)"
+            >
+              <i class="fas fa-toolbox"></i>
+            </a>
+            <a
               href="mailto:florian.motlik@gruene.at"
               class="hidden sm:inline-flex items-center gap-1.5 text-gray-700 hover:text-gruene-primary transition-colors"
               title="Bei Fragen oder Feedback an den Betreuer dieses Tools schreiben"


### PR DESCRIPTION
## Summary

Adds a visible Werkzeuge cross-link to the existing legacy header in `index.html` and `impressum.html`, pointing to the GRÜNE tool index at `grueneat.github.io/werkzeuge/`.

Positioned next to the support mailto link in the right header area, with:
- Desktop variant: toolbox icon + "Werkzeuge" label + external-link indicator
- Mobile variant: icon-only (mirrors existing mailto pattern)
- `target="_blank" rel="noopener"` since it points to an external tool

## Why now

Pragmatic step so the cross-linking works **now**, without waiting for the full `.gat-header__nav` brandbar migration. URL currently points to `grueneat.github.io/werkzeuge/`; switch to `werkzeuge.gruene.at` follows with DNS setup. Visual-consistent brandbar migration ships as a separate follow-up issue.

## Test plan

- [x] Local `npm run build` produces production HTML containing the Werkzeuge link in both `index.html` and `impressum.html`
- [x] All unit tests pass (`npm test` — 102/102)
- [ ] CI green (unit + VRT + E2E + build + deploy)
- [ ] Live verify after merge: `curl` finds `grueneat.github.io/werkzeuge` on both `/` and `/impressum.html`