### PR TITLE
Schrift auf Raleway -3 umstellen (Barlow → Raleway)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ The application supports multiple image formats defined in `TemplateConstants.TE
 - Percentage-based logo positioning for consistent placement across templates
 - Border control (0 = full-bleed, 10-20 = green border in pixels)
 - Text font is user-selectable via a descriptive 2-option picker (labelled by
-  type/use, not brand name): standard = Barlow Semi Condensed (weight 900,
+  type/use, not brand name): standard = Raleway (weight 900, -3 charSpacing tracking,
   upright; default), accent serif = Vollkorn (weight 900, italic — "Black
   Italic"). Both are
   loaded via the Google Fonts CDN. See `schriften.html` for the examples page
@@ -132,7 +132,7 @@ Logos are organized in a hierarchical structure:
 ### Styling
 
 - **Custom Theme**: GRÜNE brand colors (`gruene-primary`, `gruene-secondary`, `gruene-dark`)
-- **Typography**: Barlow Semi Condensed (Grüne-AT house font, loaded via Google Fonts)
+- **Typography**: Raleway (loaded via Google Fonts, -3 charSpacing tracking); Vollkorn for italic accents
 - **Responsive Design**: Tailwind CSS utility classes
 
 ## File Organization

--- a/impressum.html
+++ b/impressum.html
@@ -15,10 +15,10 @@
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="robots" content="noindex, nofollow" />
-    <!-- Barlow Semi Condensed (Grüne-AT house font, via Google Fonts) -->
+    <!-- Raleway (Raleway -3 brand set) + Vollkorn (accent), via Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
     <!-- Vollkorn (betonte Serifenschrift, via Google Fonts; Akzent = Black Italic) -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400;1,900&display=swap" />
     <link rel="stylesheet" href="vendors/fontawesome/css/all.css" />

--- a/index.html
+++ b/index.html
@@ -19,10 +19,10 @@
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
     <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
     <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
-    <!-- Barlow Semi Condensed (Grüne-AT house font, via Google Fonts) -->
+    <!-- Raleway (Raleway -3 brand set) + Vollkorn (accent), via Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
     <!-- Vollkorn (betonte Serifenschrift, via Google Fonts; Akzent = Black Italic) -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400;1,900&display=swap" />
     <!-- Fontawesome -->

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,6 +3,9 @@ import { cpus } from "os";
 
 export default defineConfig({
   testDir: ".",
+  // Exclude worktree copies and build/deps so discovery only sees this
+  // checkout's specs (otherwise the suite is collected once per worktree).
+  testIgnore: ["**/.worktrees/**", "**/.claude/**", "**/node_modules/**", "**/dist/**", "**/build/**"],
   testMatch: ["e2e/**/*.spec.js", "visual-regression/**/*.spec.js"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/resources/js/constants.js
+++ b/resources/js/constants.js
@@ -85,26 +85,31 @@ const AppConstants = {
 
     // Font Configuration
     FONTS: {
-        FAMILY: "Barlow Semi Condensed",
-        DEFAULT_LOGO: "Barlow Semi Condensed",
-        DEFAULT_TEXT: "Barlow Semi Condensed",
+        FAMILY: "Raleway",
+        DEFAULT_LOGO: "Raleway",
+        DEFAULT_TEXT: "Raleway",
         WEIGHT_TEXT: 900,    // default canvas text (Black)
         WEIGHT_LOGO: 800,    // logo overlay text (ExtraBold)
         WEIGHT_BOOK: 400,    // body / book equivalent (Regular)
+        // Manual tracking for fabric.js text (charSpacing, 1/1000 em).
+        // -30 = -0.03 em = the "Raleway -3" decision (tightens letters
+        // and word spacing), matching the Scribus KERN -3 of the print
+        // templates.
+        CHAR_SPACING: -30,
         // User-selectable text fonts, labelled DESCRIPTIVELY (type + use),
         // never by brand name. Option ids match #font-style-select values.
         OPTIONS: [
-            { id: 'standard', label: 'Standardschrift — Headlines & Fließtext', family: 'Barlow Semi Condensed', weight: 900, style: 'normal' },
+            { id: 'standard', label: 'Standardschrift — Headlines & Fließtext', family: 'Raleway', weight: 900, style: 'normal' },
             { id: 'accent',   label: 'Betonte Serifenschrift — für Zitate & Akzente', family: 'Vollkorn', weight: 900, style: 'italic' }
         ],
         // Each entry carries its own family so the preload observer binds to
         // the correct font. Mixing families under a single observer family
         // would leave the other font unloaded (serif fallback on first use).
         PRELOAD_FONTS: [
-            { family: 'Barlow Semi Condensed', weight: 900, style: 'italic' },  // italic accent
-            { family: 'Barlow Semi Condensed', weight: 900 },                   // default text
-            { family: 'Barlow Semi Condensed', weight: 400 },                   // book / body
-            { family: 'Barlow Semi Condensed', weight: 800 },                   // default logo
+            { family: 'Raleway', weight: 900, style: 'italic' },  // italic accent
+            { family: 'Raleway', weight: 900 },                   // default text
+            { family: 'Raleway', weight: 400 },                   // book / body
+            { family: 'Raleway', weight: 800 },                   // default logo
             { family: 'Vollkorn', weight: 900, style: 'italic' },              // accent serif (Black Italic)
             { family: 'Vollkorn', weight: 400 }                                // accent serif (book)
         ]

--- a/resources/js/event-handlers.js
+++ b/resources/js/event-handlers.js
@@ -162,6 +162,7 @@ const EventHandlerUtils = {
                 fontFamily: selectedFont,
                 fontSize: initialFontSize,
                 fontWeight: opt.weight,
+                charSpacing: AppConstants.FONTS.CHAR_SPACING,
                 fontStyle: opt.style,
                 textAlign: jQuery('input[name="align"]:checked').val(),
                 fill: jQuery("#text-color").find(":selected").attr("value"),

--- a/resources/js/handlers.js
+++ b/resources/js/handlers.js
@@ -1,6 +1,6 @@
 // Font management
 function loadFont(font) {
-    const customFonts = ['Barlow Semi Condensed', 'Vollkorn'];
+    const customFonts = ['Raleway', 'Vollkorn'];
     const text = canvas.getActiveObject();
     
     if (!text) return;

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -222,6 +222,7 @@ function addLogo() {
           fontFamily: AppConstants.FONTS.DEFAULT_LOGO,
           fontSize: Math.floor(image.getScaledWidth() / 10),
           fontWeight: AppConstants.FONTS.WEIGHT_LOGO,
+          charSpacing: AppConstants.FONTS.CHAR_SPACING,
           fontStyle: "normal",
           textAlign: "right",
           // fill is irrelevant under destination-out (only the text's alpha


### PR DESCRIPTION
Standardschrift des Font-Pickers von **Barlow Semi Condensed → Raleway** mit **-3 Tracking** (`charSpacing: -30`, fabric.js 1/1000 em = -0.03em = das Scribus-KERN-3-Äquivalent der Vorlagen). Vollkorn-Akzent unverändert.

- `constants.js`: FAMILY/DEFAULT_*/OPTIONS[standard]/PRELOAD Barlow→Raleway; `CHAR_SPACING: -30`.
- CDN (index/impressum): Barlow→Raleway (Vollkorn bleibt).
- Canvas-Text + Logo: `charSpacing` gesetzt. `handlers.js` customFonts→Raleway.
- `playwright.config.js`: `testIgnore` für Worktrees/Build/Deps.

**Hinweis Visual-Regression:** In der headless-Testumgebung laden die Google-Fonts-Webfonts nicht vor dem Canvas-Render → die Referenzen sind dort Fallback-Renders und ändern sich beim Font-Wechsel nicht; die Compare-Tests bleiben grün. Die **live deployte App** (echter Browser) lädt Raleway via CDN und rendert mit -3 Tracking — bitte am Deploy visuell gegenprüfen.