### PR TITLE
Font-Assertions auf Raleway (Deploy-Gate nach #49 reparieren)

### DIFF
--- a/tests/integration/logo-processing-integration.test.js
+++ b/tests/integration/logo-processing-integration.test.js
@@ -117,7 +117,7 @@ global.AppConstants = {
         WIDTH_SCALE: 0.95
     },
     FONTS: {
-        DEFAULT_LOGO: 'Barlow Semi Condensed'
+        DEFAULT_LOGO: 'Raleway'
     },
     COLORS: {
         WHITE: '#FFFFFF'

--- a/tests/unit/font-options.test.js
+++ b/tests/unit/font-options.test.js
@@ -29,9 +29,9 @@ describe('AppConstants.FONTS.OPTIONS', () => {
     expect(FONTS.OPTIONS.map(o => o.id)).toEqual(['standard', 'accent']);
   });
 
-  it('resolves the standard option to Barlow 900 upright', () => {
+  it('resolves the standard option to Raleway 900 upright', () => {
     const opt = lookup('standard');
-    expect(opt.family).toBe('Barlow Semi Condensed');
+    expect(opt.family).toBe('Raleway');
     expect(opt.weight).toBe(900);
     expect(opt.style).toBe('normal');
   });
@@ -55,14 +55,14 @@ describe('AppConstants.FONTS.OPTIONS', () => {
 
   it('labels both options descriptively, never by brand name', () => {
     for (const opt of FONTS.OPTIONS) {
-      expect(opt.label).not.toMatch(/Vollkorn|Barlow/i);
+      expect(opt.label).not.toMatch(/Vollkorn|Barlow|Raleway/i);
       expect(opt.label.length).toBeGreaterThan(0);
     }
   });
 
   it('preloads each font family, including Vollkorn', () => {
     const families = FONTS.PRELOAD_FONTS.map(d => d.family);
-    expect(families).toContain('Barlow Semi Condensed');
+    expect(families).toContain('Raleway');
     expect(families).toContain('Vollkorn');
     // Every preload entry must carry a family (the preload trap fix).
     expect(FONTS.PRELOAD_FONTS.every(d => typeof d.family === 'string')).toBe(true);

--- a/visual-regression/tests/test-utils.js
+++ b/visual-regression/tests/test-utils.js
@@ -264,17 +264,17 @@ export async function setupTestEnvironment(page) {
     return document.fonts.ready.then(() => true);
   }, { timeout: 30000 });
 
-  // Verify Barlow Semi Condensed fonts are loaded
+  // Verify Raleway fonts are loaded
   const fontsLoaded = await page.evaluate(async () => {
     // Wait for fonts to be ready
     await document.fonts.ready;
 
     // Check if key fonts are available
     const fonts = [
-      '900 16px "Barlow Semi Condensed"',
-      '800 16px "Barlow Semi Condensed"',
-      '400 16px "Barlow Semi Condensed"',
-      'italic 900 16px "Barlow Semi Condensed"'
+      '900 16px "Raleway"',
+      '800 16px "Raleway"',
+      '400 16px "Raleway"',
+      'italic 900 16px "Raleway"'
     ];
 
     const results = fonts.map(font => document.fonts.check(font));


### PR DESCRIPTION
Der Raleway-Merge (#49) ließ font-bezogene Test-Assertions auf `Barlow Semi Condensed` → Unit- + Visual-Regression-Jobs (und damit der Deploy) schlugen fehl. Diese Assertions prüfen den konfigurierten/geladenen Font-Namen (nicht Pixel) und sind jetzt auf Raleway umgestellt (font-options.test.js, logo-processing-integration.test.js, test-utils.js `document.fonts.check`). Jest: 130 passed lokal.