### PR TITLE
Revert Raleway-Umstellung (bis Visual-Referenzen in CI regeneriert sind)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ The application supports multiple image formats defined in `TemplateConstants.TE
 - Percentage-based logo positioning for consistent placement across templates
 - Border control (0 = full-bleed, 10-20 = green border in pixels)
 - Text font is user-selectable via a descriptive 2-option picker (labelled by
-  type/use, not brand name): standard = Raleway (weight 900, -3 charSpacing tracking,
+  type/use, not brand name): standard = Barlow Semi Condensed (weight 900,
   upright; default), accent serif = Vollkorn (weight 900, italic — "Black
   Italic"). Both are
   loaded via the Google Fonts CDN. See `schriften.html` for the examples page
@@ -132,7 +132,7 @@ Logos are organized in a hierarchical structure:
 ### Styling
 
 - **Custom Theme**: GRÜNE brand colors (`gruene-primary`, `gruene-secondary`, `gruene-dark`)
-- **Typography**: Raleway (loaded via Google Fonts, -3 charSpacing tracking); Vollkorn for italic accents
+- **Typography**: Barlow Semi Condensed (Grüne-AT house font, loaded via Google Fonts)
 - **Responsive Design**: Tailwind CSS utility classes
 
 ## File Organization

--- a/impressum.html
+++ b/impressum.html
@@ -15,10 +15,10 @@
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="robots" content="noindex, nofollow" />
-    <!-- Raleway (Raleway -3 brand set) + Vollkorn (accent), via Google Fonts -->
+    <!-- Barlow Semi Condensed (Grüne-AT house font, via Google Fonts) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
     <!-- Vollkorn (betonte Serifenschrift, via Google Fonts; Akzent = Black Italic) -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400;1,900&display=swap" />
     <link rel="stylesheet" href="vendors/fontawesome/css/all.css" />

--- a/index.html
+++ b/index.html
@@ -19,10 +19,10 @@
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
     <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
     <meta name="bingbot" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
-    <!-- Raleway (Raleway -3 brand set) + Vollkorn (accent), via Google Fonts -->
+    <!-- Barlow Semi Condensed (Grüne-AT house font, via Google Fonts) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,900&display=swap" />
     <!-- Vollkorn (betonte Serifenschrift, via Google Fonts; Akzent = Black Italic) -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400;1,900&display=swap" />
     <!-- Fontawesome -->

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,9 +3,6 @@ import { cpus } from "os";
 
 export default defineConfig({
   testDir: ".",
-  // Exclude worktree copies and build/deps so discovery only sees this
-  // checkout's specs (otherwise the suite is collected once per worktree).
-  testIgnore: ["**/.worktrees/**", "**/.claude/**", "**/node_modules/**", "**/dist/**", "**/build/**"],
   testMatch: ["e2e/**/*.spec.js", "visual-regression/**/*.spec.js"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/resources/js/constants.js
+++ b/resources/js/constants.js
@@ -85,31 +85,26 @@ const AppConstants = {
 
     // Font Configuration
     FONTS: {
-        FAMILY: "Raleway",
-        DEFAULT_LOGO: "Raleway",
-        DEFAULT_TEXT: "Raleway",
+        FAMILY: "Barlow Semi Condensed",
+        DEFAULT_LOGO: "Barlow Semi Condensed",
+        DEFAULT_TEXT: "Barlow Semi Condensed",
         WEIGHT_TEXT: 900,    // default canvas text (Black)
         WEIGHT_LOGO: 800,    // logo overlay text (ExtraBold)
         WEIGHT_BOOK: 400,    // body / book equivalent (Regular)
-        // Manual tracking for fabric.js text (charSpacing, 1/1000 em).
-        // -30 = -0.03 em = the "Raleway -3" decision (tightens letters
-        // and word spacing), matching the Scribus KERN -3 of the print
-        // templates.
-        CHAR_SPACING: -30,
         // User-selectable text fonts, labelled DESCRIPTIVELY (type + use),
         // never by brand name. Option ids match #font-style-select values.
         OPTIONS: [
-            { id: 'standard', label: 'Standardschrift — Headlines & Fließtext', family: 'Raleway', weight: 900, style: 'normal' },
+            { id: 'standard', label: 'Standardschrift — Headlines & Fließtext', family: 'Barlow Semi Condensed', weight: 900, style: 'normal' },
             { id: 'accent',   label: 'Betonte Serifenschrift — für Zitate & Akzente', family: 'Vollkorn', weight: 900, style: 'italic' }
         ],
         // Each entry carries its own family so the preload observer binds to
         // the correct font. Mixing families under a single observer family
         // would leave the other font unloaded (serif fallback on first use).
         PRELOAD_FONTS: [
-            { family: 'Raleway', weight: 900, style: 'italic' },  // italic accent
-            { family: 'Raleway', weight: 900 },                   // default text
-            { family: 'Raleway', weight: 400 },                   // book / body
-            { family: 'Raleway', weight: 800 },                   // default logo
+            { family: 'Barlow Semi Condensed', weight: 900, style: 'italic' },  // italic accent
+            { family: 'Barlow Semi Condensed', weight: 900 },                   // default text
+            { family: 'Barlow Semi Condensed', weight: 400 },                   // book / body
+            { family: 'Barlow Semi Condensed', weight: 800 },                   // default logo
             { family: 'Vollkorn', weight: 900, style: 'italic' },              // accent serif (Black Italic)
             { family: 'Vollkorn', weight: 400 }                                // accent serif (book)
         ]

--- a/resources/js/event-handlers.js
+++ b/resources/js/event-handlers.js
@@ -162,7 +162,6 @@ const EventHandlerUtils = {
                 fontFamily: selectedFont,
                 fontSize: initialFontSize,
                 fontWeight: opt.weight,
-                charSpacing: AppConstants.FONTS.CHAR_SPACING,
                 fontStyle: opt.style,
                 textAlign: jQuery('input[name="align"]:checked').val(),
                 fill: jQuery("#text-color").find(":selected").attr("value"),

--- a/resources/js/handlers.js
+++ b/resources/js/handlers.js
@@ -1,6 +1,6 @@
 // Font management
 function loadFont(font) {
-    const customFonts = ['Raleway', 'Vollkorn'];
+    const customFonts = ['Barlow Semi Condensed', 'Vollkorn'];
     const text = canvas.getActiveObject();
     
     if (!text) return;

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -222,7 +222,6 @@ function addLogo() {
           fontFamily: AppConstants.FONTS.DEFAULT_LOGO,
           fontSize: Math.floor(image.getScaledWidth() / 10),
           fontWeight: AppConstants.FONTS.WEIGHT_LOGO,
-          charSpacing: AppConstants.FONTS.CHAR_SPACING,
           fontStyle: "normal",
           textAlign: "right",
           // fill is irrelevant under destination-out (only the text's alpha

--- a/tests/integration/logo-processing-integration.test.js
+++ b/tests/integration/logo-processing-integration.test.js
@@ -117,7 +117,7 @@ global.AppConstants = {
         WIDTH_SCALE: 0.95
     },
     FONTS: {
-        DEFAULT_LOGO: 'Raleway'
+        DEFAULT_LOGO: 'Barlow Semi Condensed'
     },
     COLORS: {
         WHITE: '#FFFFFF'

--- a/tests/unit/font-options.test.js
+++ b/tests/unit/font-options.test.js
@@ -29,9 +29,9 @@ describe('AppConstants.FONTS.OPTIONS', () => {
     expect(FONTS.OPTIONS.map(o => o.id)).toEqual(['standard', 'accent']);
   });
 
-  it('resolves the standard option to Raleway 900 upright', () => {
+  it('resolves the standard option to Barlow 900 upright', () => {
     const opt = lookup('standard');
-    expect(opt.family).toBe('Raleway');
+    expect(opt.family).toBe('Barlow Semi Condensed');
     expect(opt.weight).toBe(900);
     expect(opt.style).toBe('normal');
   });
@@ -55,14 +55,14 @@ describe('AppConstants.FONTS.OPTIONS', () => {
 
   it('labels both options descriptively, never by brand name', () => {
     for (const opt of FONTS.OPTIONS) {
-      expect(opt.label).not.toMatch(/Vollkorn|Barlow|Raleway/i);
+      expect(opt.label).not.toMatch(/Vollkorn|Barlow/i);
       expect(opt.label.length).toBeGreaterThan(0);
     }
   });
 
   it('preloads each font family, including Vollkorn', () => {
     const families = FONTS.PRELOAD_FONTS.map(d => d.family);
-    expect(families).toContain('Raleway');
+    expect(families).toContain('Barlow Semi Condensed');
     expect(families).toContain('Vollkorn');
     // Every preload entry must carry a family (the preload trap fix).
     expect(FONTS.PRELOAD_FONTS.every(d => typeof d.family === 'string')).toBe(true);

--- a/visual-regression/tests/test-utils.js
+++ b/visual-regression/tests/test-utils.js
@@ -264,17 +264,17 @@ export async function setupTestEnvironment(page) {
     return document.fonts.ready.then(() => true);
   }, { timeout: 30000 });
 
-  // Verify Raleway fonts are loaded
+  // Verify Barlow Semi Condensed fonts are loaded
   const fontsLoaded = await page.evaluate(async () => {
     // Wait for fonts to be ready
     await document.fonts.ready;
 
     // Check if key fonts are available
     const fonts = [
-      '900 16px "Raleway"',
-      '800 16px "Raleway"',
-      '400 16px "Raleway"',
-      'italic 900 16px "Raleway"'
+      '900 16px "Barlow Semi Condensed"',
+      '800 16px "Barlow Semi Condensed"',
+      '400 16px "Barlow Semi Condensed"',
+      'italic 900 16px "Barlow Semi Condensed"'
     ];
 
     const results = fonts.map(font => document.fonts.check(font));


### PR DESCRIPTION
Setzt #49 + #50 zurück. Grund: Der Raleway-Wechsel ändert das gerenderte Schriftbild → die Visual-Regression-**Pixel-Baselines** müssen neu erzeugt werden. Das ist nur in einer Umgebung möglich, in der der Browser den Google-Fonts-Webfont beim Canvas-Export anwendet (CI tut das); die Hintergrund-/Headless-Umgebung exportiert einen Fallback und kann die CI-passenden Baselines nicht erzeugen. Dadurch schlug der Visual-Job fehl und der Deploy wurde übersprungen (main nicht deploybar).

Dieser Revert stellt den grünen, deploybaren Stand (Barlow) wieder her. Die Raleway-−3-Implementierung ist vollständig und liegt bereit (Commits 38c29f2/15e92ae) — sie landet erneut, sobald `npm run generate-references` in CI / auf einer Webfont-fähigen Maschine ausgeführt und die aktualisierten Baselines committet sind.