### PR TITLE
Header: einheitliche gat-header-CI, Controls in App-Leiste

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,89 +52,36 @@
         document.getElementById('dev-timestamp').style.display = 'block';
       }
     </script>
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="header py-3">
-        <div class="flex items-center justify-between gap-4">
-          <!-- Brand -->
-          <a href="index.html" class="flex items-center gap-3 shrink-0 no-underline">
-            <img
-              src="https://grueneat.github.io/design-system/assets/gruene-logo.svg"
-              width="32"
-              alt="Die Grünen"
-            />
-            <h1 class="text-gray-900 text-lg sm:text-xl font-bold uppercase leading-none whitespace-nowrap">
-              Grüner Bildgenerator
-            </h1>
+    <header class="gat-header">
+      <div class="gat-header__inner">
+        <a class="gat-header__brand" href="index.html">
+          <img class="gat-header__logo" src="https://grueneat.github.io/design-system/assets/gruene-logo.svg" alt="Die Grünen" width="150" height="132" />
+          <span class="gat-header__wordmark">Grüner Bildgenerator</span>
+        </a>
+        <nav class="gat-header__nav" aria-label="Navigation">
+          <ul class="gat-header__nav-list">
+            <li><a href="https://grueneat.github.io/werkzeuge/">Werkzeuge</a></li>
+          </ul>
+          <a href="mailto:florian.motlik@gruene.at" class="gat-header__support" title="Bei Fragen oder Feedback an den Betreuer dieses Tools schreiben" aria-label="Support-E-Mail an florian.motlik@gruene.at">
+            <svg class="gat-header__support-icon" aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6 9-6"/></svg>
+            <span class="gat-header__support-label">florian.motlik@gruene.at</span>
           </a>
-
-          <!-- Mode tabs (segmented control) -->
-          <div class="hidden md:flex items-center gap-1 bg-gray-100 rounded-lg p-1">
-            <button
-              id="tab-generator"
-              class="nav-tab active inline-flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded-md bg-gruene-primary text-white"
-            >
-              <i class="fas fa-image"></i>Bildgenerator
-            </button>
-            <button
-              id="tab-qrcode"
-              class="nav-tab inline-flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded-md text-gray-600 hover:text-gray-900 transition-colors"
-            >
-              <i class="fas fa-qrcode"></i>QR-Code
-            </button>
-          </div>
-
-          <!-- Actions -->
-          <div class="flex items-center gap-2 shrink-0">
-            <button
-              type="button"
-              class="hidden sm:inline-flex items-center gap-2 btn-sm btn-secondary"
-              id="header-examples-btn"
-              title="Beispiel-Sharepics ansehen, die mit dem Generator gestaltet wurden"
-            >
-              <i class="fas fa-images"></i>
-              <span>Beispiele</span>
-            </button>
-            <button
-              type="button"
-              class="inline-flex items-center gap-2 btn-sm btn-primary"
-              id="video-modal-btn"
-              data-video="https://www.youtube.com/embed/ukLWMNFAei0"
-            >
-              <i class="fas fa-play"></i><span class="hidden sm:inline">Erklärvideo</span>
-            </button>
-
-            <!-- Mobile-only examples (icon) -->
-            <button
-              type="button"
-              class="sm:hidden inline-flex items-center justify-center w-9 h-9 rounded-lg text-gray-600 hover:text-gruene-primary hover:bg-gray-100 transition-colors"
-              id="header-examples-btn-mobile"
-              title="Beispiele ansehen"
-              aria-label="Beispiel-Sharepics ansehen"
-            >
-              <i class="fas fa-images"></i>
-            </button>
-
-            <!-- Utility icons -->
-            <span class="hidden sm:block w-px h-6 bg-gray-200 mx-1" aria-hidden="true"></span>
-            <a
-              href="https://grueneat.github.io/werkzeuge/"
-              target="_blank"
-              rel="noopener"
-              class="hidden sm:inline-flex items-center justify-center w-9 h-9 rounded-lg text-gray-500 hover:text-gruene-primary hover:bg-gray-100 transition-colors"
-              title="Alle Werkzeuge der Grünen (externes Tool-Verzeichnis)"
-              aria-label="Werkzeuge der Grünen"
-            >
-              <i class="fas fa-toolbox"></i>
-            </a>
-            <a
-              href="mailto:florian.motlik@gruene.at"
-              class="inline-flex items-center justify-center w-9 h-9 rounded-lg text-gray-500 hover:text-gruene-primary hover:bg-gray-100 transition-colors"
-              title="Bei Fragen oder Feedback an den Betreuer dieses Tools schreiben"
-              aria-label="Kontakt / Feedback"
-            >
-              <i class="fas fa-envelope"></i>
-            </a>
-          </div>
+        </nav>
+      </div>
+    </header>
+    <!-- App-Leiste: tool-eigene Bedienelemente (Modus-Tabs + Aktionen) liegen
+         bewusst UNTER dem Header, damit die Brandbar CI-gleich zu den anderen
+         Werkzeugen bleibt ("Links rein, Controls raus"). -->
+    <div class="app-toolbar bg-white border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between gap-4">
+        <div class="hidden md:flex items-center gap-1 bg-gray-100 rounded-lg p-1">
+          <button id="tab-generator" class="nav-tab active inline-flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded-md bg-gruene-primary text-white"><i class="fas fa-image"></i>Bildgenerator</button>
+          <button id="tab-qrcode" class="nav-tab inline-flex items-center gap-2 px-4 py-1.5 text-sm font-medium rounded-md text-gray-600 hover:text-gray-900 transition-colors"><i class="fas fa-qrcode"></i>QR-Code</button>
+        </div>
+        <div class="flex items-center gap-2 shrink-0">
+          <button type="button" class="hidden sm:inline-flex items-center gap-2 btn-sm btn-secondary" id="header-examples-btn" title="Beispiel-Sharepics ansehen, die mit dem Generator gestaltet wurden"><i class="fas fa-images"></i><span>Beispiele</span></button>
+          <button type="button" class="inline-flex items-center gap-2 btn-sm btn-primary" id="video-modal-btn" data-video="https://www.youtube.com/embed/ukLWMNFAei0"><i class="fas fa-play"></i><span class="hidden sm:inline">Erklärvideo</span></button>
+          <button type="button" class="sm:hidden inline-flex items-center justify-center w-9 h-9 rounded-lg text-gray-600 hover:text-gruene-primary hover:bg-gray-100 transition-colors" id="header-examples-btn-mobile" title="Beispiele ansehen" aria-label="Beispiel-Sharepics ansehen"><i class="fas fa-images"></i></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Teil der CI-Vereinheitlichung aller Werkzeug-Header (ko7j9).

- Header auf den gemeinsamen `.gat-header` umgestellt (Logo + Wortmarke "Gruener Bildgenerator" + Werkzeuge-Link + Support-Mail) — identisch zu den anderen Werkzeugen.
- Modus-Tabs (Bildgenerator/QR-Code) und Aktionen (Beispiele, Erklaervideo) aus dem Header in eine App-Leiste direkt darunter verschoben ("Links rein, Controls raus"). Alle IDs unveraendert -> Tab-/Modal-JS bleibt funktionsfaehig.

Visuell geprueft (Build): Header identisch zur DS-Vorlage, Controls in der Leiste.