### PR TITLE
DS-Referenzen auf design-system.gruene.at umstellen

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="resources/favicon/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="16x16" href="resources/favicon/favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="resources/favicon/favicon-32x32.png" />
-    <link rel="icon" type="image/svg+xml" href="https://grueneat.github.io/design-system/assets/gruene-logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="https://design-system.gruene.at/assets/gruene-logo.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="resources/favicon/apple-touch-icon.png" />
     <link rel="mask-icon" href="resources/favicon/safari-pinned-tab.svg" color="#2d793c" />
     <link rel="manifest" href="resources/favicon/site.webmanifest" />
@@ -22,7 +22,7 @@
     <!-- Vollkorn (betonte Serifenschrift, via Google Fonts; Akzent = Black Italic) -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400;1,900&display=swap" />
     <link rel="stylesheet" href="vendors/fontawesome/css/all.css" />
-    <link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css" />
+    <link rel="stylesheet" href="https://design-system.gruene.at/design-system.css" />
     <link rel="stylesheet" href="resources/css/output.css?v=1.5" />
     <link rel="stylesheet" type="text/css" media="screen" href="resources/css/style.css?v=1.5" />
   </head>
@@ -33,7 +33,7 @@
       <div class="header uppercase py-3">
         <div class="flex items-center justify-between">
           <a href="index.html" class="flex items-center gap-3 no-underline">
-            <img src="https://grueneat.github.io/design-system/assets/gruene-logo.svg" width="32" alt="Die Gruenen" />
+            <img src="https://design-system.gruene.at/assets/gruene-logo.svg" width="32" alt="Die Gruenen" />
             <h1 class="text-gray-900 text-xl font-bold">Grüner Bildgenerator</h1>
           </a>
           <div class="flex items-center gap-2 text-sm">

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="resources/favicon/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="16x16" href="resources/favicon/favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="resources/favicon/favicon-32x32.png" />
-    <link rel="icon" type="image/svg+xml" href="https://grueneat.github.io/design-system/assets/gruene-logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="https://design-system.gruene.at/assets/gruene-logo.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="resources/favicon/apple-touch-icon.png" />
     <link rel="mask-icon" href="resources/favicon/safari-pinned-tab.svg" color="#2d793c" />
     <link rel="manifest" href="resources/favicon/site.webmanifest" />
@@ -28,7 +28,7 @@
     <!-- Fontawesome -->
     <link rel="stylesheet" href="vendors/fontawesome/css/all.css" />
     <!-- Gruene Design System -->
-    <link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css" />
+    <link rel="stylesheet" href="https://design-system.gruene.at/design-system.css" />
     <!-- Tailwind CSS -->
     <link rel="stylesheet" href="resources/css/output.css?v=1.5" />
     <!-- Custom styles -->
@@ -55,7 +55,7 @@
     <header class="gat-header">
       <div class="gat-header__inner">
         <a class="gat-header__brand" href="index.html">
-          <img class="gat-header__logo" src="https://grueneat.github.io/design-system/assets/gruene-logo.svg" alt="Die Grünen" width="150" height="132" />
+          <img class="gat-header__logo" src="https://design-system.gruene.at/assets/gruene-logo.svg" alt="Die Grünen" width="150" height="132" />
           <span class="gat-header__wordmark">Grüner Bildgenerator</span>
         </a>
         <nav class="gat-header__nav" aria-label="Navigation">

--- a/schriften.html
+++ b/schriften.html
@@ -8,11 +8,11 @@
 <link rel="icon" href="resources/favicon/favicon.ico" sizes="any">
 <link rel="icon" type="image/png" sizes="16x16" href="resources/favicon/favicon-16x16.png">
 <link rel="icon" type="image/png" sizes="32x32" href="resources/favicon/favicon-32x32.png">
-<link rel="icon" type="image/svg+xml" href="https://grueneat.github.io/design-system/assets/gruene-logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://design-system.gruene.at/assets/gruene-logo.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="resources/favicon/apple-touch-icon.png">
 <!-- Grüne AT Design System (gehostet). Lädt Barlow Semi Condensed + Vollkorn
      selbst und liefert die gat-Komponenten + --gat-*-Tokens. -->
-<link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css">
+<link rel="stylesheet" href="https://design-system.gruene.at/design-system.css">
 <style>
   /* design-system.css setzt bewusst KEINE Tag-Defaults — das body-Grundlayout
      muss die konsumierende Seite selbst aus den --gat-*-Tokens setzen. */
@@ -71,7 +71,7 @@
     <div class="gat-header__inner">
       <a class="gat-header__brand" href="index.html">
         <img class="gat-header__logo"
-             src="https://grueneat.github.io/design-system/assets/gruene-logo.svg"
+             src="https://design-system.gruene.at/assets/gruene-logo.svg"
              alt="Die Grünen">
         <span class="gat-header__wordmark">Grüner Bildgenerator</span>
       </a>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -77,7 +77,7 @@ async function createProductionHTML() {
     // tokens (var(--gat-*)) used by the bundled Tailwind utilities resolve.
     html = html.replace(
         /<link rel="stylesheet" href="vendors\/fontawesome\/css\/all\.css"\s*\/?>[\s\S]*?<link rel="stylesheet"[\s\S]*?href="resources\/css\/style\.css\?v=[\d\.]+"\s*\/?>/g,
-        '<link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css">\n    <link rel="stylesheet" href="app.min.css">'
+        '<link rel="stylesheet" href="https://design-system.gruene.at/design-system.css">\n    <link rel="stylesheet" href="app.min.css">'
     );
 
     // Replace vendor JavaScript files with bundled version
@@ -114,7 +114,7 @@ async function createStaticPage(filename) {
 
     html = html.replace(
         /<link rel="stylesheet" href="vendors\/fontawesome\/css\/all\.css"\s*\/?>[\s\S]*?<link rel="stylesheet"[\s\S]*?href="resources\/css\/style\.css\?v=[\d\.]+"\s*\/?>/g,
-        '<link rel="stylesheet" href="https://grueneat.github.io/design-system/design-system.css">\n    <link rel="stylesheet" href="app.min.css">'
+        '<link rel="stylesheet" href="https://design-system.gruene.at/design-system.css">\n    <link rel="stylesheet" href="app.min.css">'
     );
 
     const timestamp = Date.now();


### PR DESCRIPTION
Stellt alle Design-System-Referenzen (CSS, Logo/Assets, gat-charts.js) von grueneat.github.io/design-system/ auf https://design-system.gruene.at/ um. Die alte URL leitet per 301 auf http:// weiter (Mixed-Content-Risiko fuers Stylesheet). GitHub-Repo-Links bleiben unveraendert.