### PR TITLE
Cross-Tool-Links auf Custom-Domains umstellen

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -37,7 +37,7 @@
             <h1 class="text-gray-900 text-xl font-bold">Grüner Bildgenerator</h1>
           </a>
           <div class="flex items-center gap-2 text-sm">
-            <a href="https://grueneat.github.io/werkzeuge/"
+            <a href="https://werkzeuge.gruene.at/"
                target="_blank"
                rel="noopener"
                class="hidden sm:inline-flex items-center gap-1.5 text-gray-700 hover:text-gruene-primary transition-colors"
@@ -46,7 +46,7 @@
               <span class="font-medium">Werkzeuge</span>
               <i class="fas fa-arrow-up-right-from-square text-xs text-gray-400" aria-hidden="true"></i>
             </a>
-            <a href="https://grueneat.github.io/werkzeuge/"
+            <a href="https://werkzeuge.gruene.at/"
                target="_blank"
                rel="noopener"
                class="sm:hidden inline-flex items-center text-gray-700 hover:text-gruene-primary"

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         </a>
         <nav class="gat-header__nav" aria-label="Navigation">
           <ul class="gat-header__nav-list">
-            <li><a href="https://grueneat.github.io/werkzeuge/">Werkzeuge</a></li>
+            <li><a href="https://werkzeuge.gruene.at/">Werkzeuge</a></li>
           </ul>
           <a href="mailto:florian.motlik@gruene.at" class="gat-header__support" title="Bei Fragen oder Feedback an den Betreuer dieses Tools schreiben" aria-label="Support-E-Mail an florian.motlik@gruene.at">
             <svg class="gat-header__support-icon" aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6 9-6"/></svg>


### PR DESCRIPTION
Stellt die Verlinkung zwischen den Werkzeugen auf die neuen Custom-Domains um (Werkzeuge-Hub werkzeuge.gruene.at; in werkzeuge zusaetzlich die Tool-Karten gemeindefinanzen/vorlagen.noe/personenwahl). Externe Tools (gruenerator/jitsi/termino) bleiben unveraendert.