### PR TITLE
fix(logo): zu breite Logo-Namen auf Balkenbreite skalieren

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -242,13 +242,21 @@ function addLogo() {
         // not double-rendered.
         canvas.add(logoName);
 
-        const linebreak = logoText.lastIndexOf("\n");
-        if (linebreak > 17 || logoText.length - linebreak > 17) {
-          logoName.scaleToWidth(image.getScaledWidth() * AppConstants.LOGO.WIDTH_SCALE);
+        // Fit the region name to the bar by ACTUAL rendered width, not by a
+        // character-count heuristic. Some names that stay on one line (e.g.
+        // "OBERHOFEN/IRRSEE", or any name without a space to break on) are still
+        // wider than the bar; the old length check left them unscaled so the
+        // right-aligned text overflowed and clipped the leading letter. Whenever
+        // the text is wider than the available bar width we scale it down to fit;
+        // otherwise we keep its natural size and just set the box width so the
+        // right-alignment/centering stays unchanged for names that already fit.
+        const availableWidth = image.getScaledWidth() * AppConstants.LOGO.WIDTH_SCALE;
+        if (logoName.getScaledWidth() > availableWidth) {
+          logoName.scaleToWidth(availableWidth);
           const topAdd = Math.floor((logoName.height - logoName.getScaledHeight()) / 2);
           logoName.top = logoName.top + topAdd;
         } else {
-          logoName.width = image.getScaledWidth() * AppConstants.LOGO.WIDTH_SCALE;
+          logoName.width = availableWidth;
         }
 
         canvas.centerObjectH(logoName);

--- a/tests/integration/logo-processing-integration.test.js
+++ b/tests/integration/logo-processing-integration.test.js
@@ -55,6 +55,10 @@ global.fabric = {
         this.height = 20;
         this.top = options.top || 0;
         this.scaleToWidth = jest.fn();
+        // Mirror real fabric.Text: getScaledWidth() = width * scaleX (scaleX
+        // defaults to 1). addLogo() reads this to decide whether the region name
+        // overflows the bar and must be scaled down to fit.
+        this.getScaledWidth = () => this.width;
         this.getScaledHeight = () => 20;
         this.set = jest.fn();
     }),
@@ -405,6 +409,48 @@ describe('Logo Processing Integration Tests', () => {
             // Caching on => the destination-out child composites within the group's
             // own cache (transparent holes) before toDataURL flattens it.
             expect(groupOptions.objectCaching).toBe(true);
+        });
+
+        // Available bar width = image.getScaledWidth() (200) * WIDTH_SCALE (0.95) = 190.
+        test('a region name wider than the bar is scaled down to fit (no clipping)', () => {
+            // Force the next text instance to be wider than the bar so the overflow
+            // branch runs. This is the regression guard for long single-line names
+            // (e.g. OBERHOFEN/IRRSEE) that previously overflowed and clipped left.
+            fabric.Text.mockImplementationOnce(function (text, options) {
+                this.text = text;
+                this.options = options;
+                this.width = 300; // > 190 => overflows the bar
+                this.height = 20;
+                this.top = options.top || 0;
+                this.scaleToWidth = jest.fn();
+                this.getScaledWidth = () => this.width;
+                this.getScaledHeight = () => 20;
+                this.set = jest.fn();
+            });
+
+            jQuery('#logo-selection').html(`
+                <option value="WIEN" selected>WIEN</option>
+            `);
+
+            addLogo();
+
+            const textInstance = fabric.Text.mock.instances[0];
+            // Scaled to exactly the available bar width so nothing is clipped.
+            expect(textInstance.scaleToWidth).toHaveBeenCalledWith(190);
+        });
+
+        test('a region name that already fits keeps its size (only box width is set)', () => {
+            jQuery('#logo-selection').html(`
+                <option value="WIEN" selected>WIEN</option>
+            `);
+
+            addLogo();
+
+            const textInstance = fabric.Text.mock.instances[0];
+            // Default mock width 100 <= 190 => not scaled down; the box width is
+            // set to the available area for right-alignment/centering.
+            expect(textInstance.scaleToWidth).not.toHaveBeenCalled();
+            expect(textInstance.width).toBe(190);
         });
     });
 });


### PR DESCRIPTION
## Problem

Lange einzeilige Gemeindenamen ohne Umbruchpunkt (z. B. **Oberhofen/Irrsee**, 16 Zeichen, kein Leerzeichen/`%`) wurden nicht verkleinert. Die Entscheidung, ob der Name skaliert wird, lief über eine **Zeichenanzahl-Heuristik** statt über die tatsächliche Breite. Dadurch landete dieser Name im „nicht skalieren"-Zweig, der nur die Box-Breite setzt. Bei `textAlign: "right"` lief der Text links über den weißen Balken hinaus und das führende **O** wurde abgeschnitten.

## Fix

In `resources/js/main.js` (`addLogo`) entscheidet die Anpassung jetzt anhand der **gerenderten Breite**:

```js
const availableWidth = image.getScaledWidth() * AppConstants.LOGO.WIDTH_SCALE;
if (logoName.getScaledWidth() > availableWidth) {
  logoName.scaleToWidth(availableWidth);   // zu breit -> verkleinern
  // ...vertikal nachzentrieren...
} else {
  logoName.width = availableWidth;          // passt -> unveraendert
}
```

Strikt korrekter als zuvor: **jeder** ueberlaufende Name wird auf die Balkenbreite skaliert, egal ob ein Umbruchpunkt existiert. Passende Namen (z. B. `WIEN`) bleiben unveraendert -> keine Regression.

## Verifikation

Ueber die echte UI getestet (Searchable-Select -> `addLogo()` -> Knockout-Flatten), Canvas via `canvas.toDataURL()` exportiert (gleicher Pfad wie der Download):

- **vorher:** `OBERHOFEN/IRRSEE` laeuft links ueber den Balken, "O" abgeschnitten
- **nachher:** `OBERHOFEN/IRRSEE` vollstaendig im Balken, gleichmaessige Raender